### PR TITLE
fix(codegen): handle felt to integer in ConvertField

### DIFF
--- a/zkx/mlir/BUILD.bazel
+++ b/zkx/mlir/BUILD.bazel
@@ -13,7 +13,7 @@
 # limitations under the License.
 # ==============================================================================
 
-load("//bazel:zkx_cc.bzl", "zkx_cc_library")
+load("//bazel:zkx_cc.bzl", "zkx_cc_library", "zkx_cc_test")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -28,6 +28,17 @@ zkx_cc_library(
         "@llvm-project//mlir:SCFDialect",
         "@llvm-project//mlir:Support",
         "@prime_ir//prime_ir/Dialect/EllipticCurve/IR:EllipticCurve",
+        "@prime_ir//prime_ir/Dialect/Field/IR:Field",
+    ],
+)
+
+zkx_cc_test(
+    name = "codegen_utils_unittest",
+    srcs = ["codegen_utils_unittest.cc"],
+    deps = [
+        ":codegen_utils",
+        "@llvm-project//mlir:ArithDialect",
+        "@llvm-project//mlir:IR",
         "@prime_ir//prime_ir/Dialect/Field/IR:Field",
     ],
 )

--- a/zkx/mlir/codegen_utils.cc
+++ b/zkx/mlir/codegen_utils.cc
@@ -313,6 +313,38 @@ Value ConvertField(ImplicitLocOpBuilder& b, ArrayRef<Type> result_types,
     }
   }
 
+  if (auto pf_element_type =
+          dyn_cast<prime_ir::field::PrimeFieldType>(source_element_type)) {
+    if (auto integer_type = dyn_cast<IntegerType>(target_element_type)) {
+      unsigned src_width = pf_element_type.getStorageType().getWidth();
+      unsigned dst_width = integer_type.getWidth();
+      Value current_val = args[0];
+
+      if (pf_element_type.isMontgomery()) {
+        Type std_source_type =
+            prime_ir::field::getStandardFormType(source_type);
+        current_val = b.create<prime_ir::field::FromMontOp>(std_source_type,
+                                                            current_val);
+      }
+
+      Type src_storage_type = pf_element_type.getStorageType();
+      if (auto shaped_type = dyn_cast<ShapedType>(current_val.getType())) {
+        src_storage_type = shaped_type.clone(src_storage_type);
+      }
+      current_val =
+          b.create<prime_ir::field::BitcastOp>(src_storage_type, current_val);
+
+      Type result_type = result_types.front();
+      if (dst_width < src_width) {
+        return b.create<arith::TruncIOp>(result_type, current_val);
+      }
+      if (dst_width > src_width) {
+        return b.create<arith::ExtUIOp>(result_type, current_val);
+      }
+      return current_val;
+    }
+  }
+
   if (prime_ir::field::isMontgomery(source_type)) {
     if (prime_ir::field::isMontgomery(target_type)) {
       return args[0];

--- a/zkx/mlir/codegen_utils_unittest.cc
+++ b/zkx/mlir/codegen_utils_unittest.cc
@@ -1,0 +1,111 @@
+/* Copyright 2026 The ZKX Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "zkx/mlir/codegen_utils.h"
+
+#include "gtest/gtest.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/ImplicitLocOpBuilder.h"
+#include "mlir/IR/MLIRContext.h"
+#include "prime_ir/Dialect/Field/IR/FieldDialect.h"
+#include "prime_ir/Dialect/Field/IR/FieldOps.h"
+#include "prime_ir/Dialect/Field/IR/FieldTypes.h"
+
+namespace zkx::mlir_utils {
+namespace {
+
+using ::mlir::arith::TruncIOp;
+using ::mlir::prime_ir::field::BitcastOp;
+using ::mlir::prime_ir::field::FromMontOp;
+using ::mlir::prime_ir::field::PrimeFieldType;
+
+class ConvertFieldTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    context_.loadDialect<mlir::arith::ArithDialect,
+                         mlir::prime_ir::field::FieldDialect>();
+  }
+
+  PrimeFieldType MakeFieldType(unsigned storage_bits, bool montgomery) {
+    auto modulus =
+        mlir::IntegerAttr::get(mlir::IntegerType::get(&context_, storage_bits),
+                               (1u << 4) + 1);  // small odd prime stand-in
+    return PrimeFieldType::get(&context_, modulus, montgomery);
+  }
+
+  mlir::MLIRContext context_;
+};
+
+// Regression: ConvertField(felt → smaller integer) used to fall through to
+// `return args[0]`, leaking the felt-typed Value into a position the caller
+// declared as integer. AES-256-encrypt's GPU JIT then crashed inside
+// ClampIndex with `arith.index_cast operand must be signless-integer-like,
+// but got !field.pf<...>`.
+TEST_F(ConvertFieldTest, FeltStandardFormToSmallerIntegerProducesTrunc) {
+  mlir::OpBuilder b(&context_);
+  mlir::ImplicitLocOpBuilder lb(b.getUnknownLoc(), b);
+
+  auto block = std::make_unique<mlir::Block>();
+  lb.setInsertionPointToStart(block.get());
+
+  PrimeFieldType felt = MakeFieldType(/*storage_bits=*/256, /*montgomery=*/false);
+  mlir::Type i32 = lb.getIntegerType(32);
+
+  mlir::Value placeholder = block->addArgument(felt, lb.getUnknownLoc());
+  mlir::Value result = ConvertField(lb, /*result_types=*/{i32},
+                                    /*source_type=*/felt,
+                                    /*target_type=*/i32, {placeholder});
+
+  ASSERT_TRUE(result);
+  EXPECT_EQ(result.getType(), i32);
+  auto trunc = result.getDefiningOp<TruncIOp>();
+  ASSERT_TRUE(trunc) << "expected trailing arith.trunci";
+  auto bitcast = trunc.getIn().getDefiningOp<BitcastOp>();
+  ASSERT_TRUE(bitcast) << "expected field.bitcast feeding the trunc";
+  EXPECT_EQ(bitcast.getInput(), placeholder);
+}
+
+TEST_F(ConvertFieldTest, FeltMontgomeryToIntegerInsertsFromMontFirst) {
+  mlir::OpBuilder b(&context_);
+  mlir::ImplicitLocOpBuilder lb(b.getUnknownLoc(), b);
+
+  auto block = std::make_unique<mlir::Block>();
+  lb.setInsertionPointToStart(block.get());
+
+  PrimeFieldType mont_felt = MakeFieldType(/*storage_bits=*/256,
+                                           /*montgomery=*/true);
+  mlir::Type i32 = lb.getIntegerType(32);
+
+  mlir::Value placeholder = block->addArgument(mont_felt, lb.getUnknownLoc());
+  mlir::Value result = ConvertField(lb, /*result_types=*/{i32},
+                                    /*source_type=*/mont_felt,
+                                    /*target_type=*/i32, {placeholder});
+
+  ASSERT_TRUE(result);
+  EXPECT_EQ(result.getType(), i32);
+  auto trunc = result.getDefiningOp<TruncIOp>();
+  ASSERT_TRUE(trunc);
+  auto bitcast = trunc.getIn().getDefiningOp<BitcastOp>();
+  ASSERT_TRUE(bitcast);
+  auto from_mont = bitcast.getInput().getDefiningOp<FromMontOp>();
+  ASSERT_TRUE(from_mont) << "Montgomery source must be normalized via from_mont";
+  EXPECT_EQ(from_mont.getInput(), placeholder);
+}
+
+}  // namespace
+}  // namespace zkx::mlir_utils


### PR DESCRIPTION
## Description

`ConvertField` had no path for prime-field source to integer target. The
mont source / non-mont target branch built an ill-typed
`FromMontOp(result_types=integer, ...)` (`FromMont` produces standard-form
felt, not int), and the non-mont source / non-mont target branch returned
`args[0]` verbatim, leaking the felt-typed Value into a position the caller
had declared as integer.

Downstream emitters that consumed the ostensibly-integer result then
crashed at JIT verification: `ClampIndex` (called from `EmitDynamicSlice`
/ `EmitDynamicUpdateSlice` in `elemental_hlo_to_mlir.cc`) emitted
`arith.index_cast` on the felt and the arith verifier rejected it
(`operand #0 must be signless-integer-like, but got !field.pf<...>`).
AES-256-encrypt is the smallest circuit that exercises this — its
felt-typed loop counter feeds `dynamic_slice` indices via a
`stablehlo.convert(felt -> i32)`.

The fix mirrors the existing int-to-felt path: normalize a Montgomery
source via `field.from_mont`, bitcast standard-form felt to its integer
storage type via `field.bitcast`, then `arith.trunci` / `arith.extui` to
the target width.

`codegen_utils_unittest.cc` adds two regressions: standard-form felt to a
smaller integer (must end in `arith.trunci` with `field.bitcast` as the
operand) and Montgomery felt to integer (additionally must insert
`field.from_mont` before the bitcast). Verified by toggling the patch
out — both cases fail without it, pass with it.

End-to-end validation: AES-256-encrypt now JITs and runs on RTX 5090.
N=4096 measured at 3132 wits/s through the llzk-to-shlo m3_runner harness
(13.3x over cpu_circom). MontgomeryDouble unchanged.

## Related Issues/PRs

Unblocks llzk-to-shlo M3 Phase 1 anchor A measurement.

## Checklist

- [x] Branch name follows Branch Guideline
- [x] Commit messages follow Commit Message Guideline
- [x] Checked Pull Request Guideline